### PR TITLE
fix: Correct SyntaxError from 'return' outside function

### DIFF
--- a/chatgpt.py
+++ b/chatgpt.py
@@ -346,7 +346,7 @@ if st.button("Ask"):
                         else:
                             # If no text and no file/image, warn and exit
                             st.warning("Please enter a question or upload a file.")
-                            return
+                            st.stop()
 
                     messages_payload[0]["content"] = current_content_parts
 
@@ -389,7 +389,7 @@ if st.button("Ask"):
                     # Ensure the final prompt for Ollama is not empty
                     if not ollama_prompt_str.strip():
                          st.warning("Please enter a question or upload a file for the Ollama model.")
-                         return
+                         st.stop()
 
                     # Execute Ollama command
                     result = subprocess.run(
@@ -409,7 +409,7 @@ if st.button("Ask"):
                     # Ensure there's content to send
                     if not messages_payload[0]["content"]:
                         st.warning("Please enter a question to accompany the uploaded file.")
-                        return
+                        st.stop()
 
                     # Make the API call to OpenAI
                     # Note: client.responses.create seems to be a placeholder or custom SDK method.


### PR DESCRIPTION
I replaced 'return' statements with 'st.stop()' within the main script body (specifically, inside the st.button('Ask') block).

In Streamlit, 'st.stop()' is the correct way to halt the execution of a script block triggered by an event, while 'return' is only valid within a function definition. This change resolves the SyntaxError: 'return' outside function that was occurring and ensures the script behaves as intended by stopping execution when necessary inputs are not provided.